### PR TITLE
Adding class for simplifing generic sheets pattern

### DIFF
--- a/client/pages/_states/_index.vue
+++ b/client/pages/_states/_index.vue
@@ -126,7 +126,7 @@
       </div>
     </cov-section>
 
-    <cov-section v-if="showCases" color="melrose">
+    <cov-section v-if="showCasesSection" color="melrose">
       <div class="container">
         <cov-grid gutter justify-between>
           <!-- <cov-grid-cell :breakpoints="{ col: '1-of-2', sm: 'full', md: 'full' }"> -->
@@ -197,7 +197,7 @@
         </cov-grid>
       </div>
     </cov-section>
-    <cov-section v-if="showVaccine" class="cov-section__vaccine flex items-center">
+    <cov-section v-if="showVaccineSection" class="cov-section__vaccine flex items-center">
       <div class="container">
         <div class="vaccine">
           <cov-grid-cell :breakpoints="{ sm:'10-of-12', md:'8-of-12', lg:'3-of-6' }">
@@ -295,12 +295,6 @@ export default {
         confirmed: { label: 'Confirmados', img: 'purple-line.svg', value: true },
         recovered: { label: 'Recuperados', img: 'green-line.svg', value: true },
         deaths: { label: 'Óbitos', img: 'red-line.svg', value: true }
-      },
-      citiesContent: {
-        'ribeirao-preto': { label: 'Ribeirão Preto', sections: ['cases', 'vaccine'], vaccineLink: 'https://www.ribeiraopreto.sp.gov.br/agendamento-vacinacao-covid/' },
-        batatais: { label: 'Batatais', sections: ['vaccine'], vaccineLink: 'http://www.batatais.sp.gov.br/vacina/controlecidadao/' },
-        cajuru: { label: 'Cajuru', sections: [] },
-        paulinia: { label: 'Paulinia', sections: ['cases'], vaccineLink: '' }
       }
     }
   },
@@ -314,6 +308,29 @@ export default {
       params: 'dashboard/params'
     }),
 
+    citiesContent () {
+      return {
+        'ribeirao-preto': {
+          label: 'Ribeirão Preto',
+          sections: ['cases', 'vaccine'],
+          vaccineLink: 'https://www.ribeiraopreto.sp.gov.br/agendamento-vacinacao-covid/'
+        },
+        batatais: {
+          label: 'Batatais',
+          sections: ['vaccine'],
+          vaccineLink: 'http://www.batatais.sp.gov.br/vacina/controlecidadao/'
+        },
+        cajuru: {
+          label: 'Cajuru'
+        },
+        paulinia: {
+          label: 'Paulinia',
+          sections: ['cases'],
+          vaccineLink: ''
+        }
+      }
+    },
+
     dateShortcuts () {
       return shortcuts
     },
@@ -322,12 +339,12 @@ export default {
       return this.$route.params.index
     },
 
-    showVaccine () {
-      return this.citiesContent[this.currentCity].sections.includes('vaccine')
+    showVaccineSection () {
+      return this.citiesContent[this.currentCity]?.sections?.includes('vaccine')
     },
 
-    showCases () {
-      return this.citiesContent[this.currentCity].sections.includes('cases')
+    showCasesSection () {
+      return this.citiesContent[this.currentCity]?.sections?.includes('cases')
     },
 
     beds () {

--- a/client/pages/_states/_index.vue
+++ b/client/pages/_states/_index.vue
@@ -126,7 +126,7 @@
       </div>
     </cov-section>
 
-    <cov-section color="melrose">
+    <cov-section v-if="showCases" color="melrose">
       <div class="container">
         <cov-grid gutter justify-between>
           <!-- <cov-grid-cell :breakpoints="{ col: '1-of-2', sm: 'full', md: 'full' }"> -->
@@ -197,14 +197,14 @@
         </cov-grid>
       </div>
     </cov-section>
-    <cov-section v-if="isRibeirao" class="cov-section__vaccine flex items-center">
+    <cov-section v-if="showVaccine" class="cov-section__vaccine flex items-center">
       <div class="container">
         <div class="vaccine">
           <cov-grid-cell :breakpoints="{ sm:'10-of-12', md:'8-of-12', lg:'3-of-6' }">
-            <h2>A Prefeitura de Ribeirão Preto já está disponibilizando o agendamento para vacinação contra COVID-19.</h2>
+            <h2>A Prefeitura de {{ citiesContent[currentCity].label }} já está disponibilizando o agendamento para vacinação contra COVID-19.</h2>
           </cov-grid-cell>
           <div class="vaccine__button">
-            <cov-button class="cov-button--vaccine m-t-xl" href="https://www.ribeiraopreto.sp.gov.br/agendamento-vacinacao-covid/" label="Agende agora" />
+            <cov-button class="cov-button--vaccine m-t-xl" :href="citiesContent[currentCity].vaccineLink" label="Agende agora" target="_blank" />
           </div>
         </div>
       </div>
@@ -295,6 +295,12 @@ export default {
         confirmed: { label: 'Confirmados', img: 'purple-line.svg', value: true },
         recovered: { label: 'Recuperados', img: 'green-line.svg', value: true },
         deaths: { label: 'Óbitos', img: 'red-line.svg', value: true }
+      },
+      citiesContent: {
+        'ribeirao-preto': { label: 'Ribeirão Preto', sections: ['cases', 'vaccine'], vaccineLink: 'https://www.ribeiraopreto.sp.gov.br/agendamento-vacinacao-covid/' },
+        batatais: { label: 'Batatais', sections: ['vaccine'], vaccineLink: 'http://www.batatais.sp.gov.br/vacina/controlecidadao/' },
+        cajuru: { label: 'Cajuru', sections: [] },
+        paulinia: { label: 'Paulinia', sections: ['cases'], vaccineLink: '' }
       }
     }
   },
@@ -316,8 +322,12 @@ export default {
       return this.$route.params.index
     },
 
-    isRibeirao () {
-      return this.currentCity === 'ribeirao-preto'
+    showVaccine () {
+      return this.citiesContent[this.currentCity].sections.includes('vaccine')
+    },
+
+    showCases () {
+      return this.citiesContent[this.currentCity].sections.includes('cases')
     },
 
     beds () {
@@ -659,6 +669,8 @@ export default {
 
     mapCenter () {
       const positions = {
+        batatais: [-20.8916, -47.5856],
+        cajuru: [-21.2958274, -47.3303524],
         'ribeirao-preto': [-21.1775, -47.81028],
         paulinia: [-22.7624246, -47.15619]
       }

--- a/server/app/models/data_bridge/generic_city_drive.rb
+++ b/server/app/models/data_bridge/generic_city_drive.rb
@@ -9,6 +9,7 @@ module DataBridge
     TO_DO_TYPES = %i[beds cases].freeze
 
     attr_accessor :city, :hospital, :credentials, :to_do, :cases_results
+    # Makes the 'save!' method from super class be called 'super_save!', so it can be accessed anywhere
     alias super_save! save!
 
     def initialize(city, to_do: TO_DO_TYPES)
@@ -32,8 +33,10 @@ module DataBridge
 
       file = get_data_from_google_drive(credentials)
 
+      # Treats each datas separately
       to_do.each do |type|
         @worksheet = file.worksheets[TO_DO_TYPES.index(type)]
+        # Hard send is defined later on the code
         hard_send("process_#{type}")
       end
 
@@ -98,9 +101,12 @@ module DataBridge
       )
     end
 
-    # Since it's a very generic class, it's very well protected to avoid unnecessary debugs
+    # Since it's a very generic class, it's very well protected to avoid too much debugging
     private
 
+    # It's the same thing as usual send, but warns the developer in case he miss the method creation
+    # Might be useless, but since it's a class that might be used for a lot of cities, and might be
+    # used as another class' superclass, this method might help to abstract this class and debug
     def hard_send(symbol)
       begin
         send_method = method(symbol)

--- a/server/app/models/data_bridge/generic_city_drive.rb
+++ b/server/app/models/data_bridge/generic_city_drive.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+module DataBridge
+  # This class has the intend to simplify future generic google drive sheets
+  class CityDriveBase < DataBridge::GoogleDriveBase
+    MULTIPLE_HOSPITAL_WARNING = I18n.t('development_notes.hospital_warning')
+    HOSPITAL_NOT_FOUND_MESSAGE = I18n.t('activerecord.passive_errors.not_found', count: 1, arg: Hospital.model_name.human)
+    CREDENTIALS_NOT_FOUND_MESSAGE = I18n.t('activerecord.passive_errors.not_found', count: 2, arg: I18n.t('development_notes.credentials'))
+    TO_DO_TYPES = %i[beds cases].freeze
+
+    attr_accessor :city, :hospital, :credentials, :to_do, :cases_results
+    alias super_save! save!
+
+    def initialize(city, to_do: TO_DO_TYPES)
+      self.city = (city.is_a?(City) ? city : City.friendly.find(city))
+      self.hospital = retrieve_hospital
+      self.credentials = retrieve_credentials
+      self.to_do = [to_do].flatten.freeze
+
+      super()
+    end
+
+    def save!
+      to_do.each { |type| hard_send("save_#{type}") }
+
+      true
+    end
+
+    def get_data
+      self.results = []
+      self.cases_results = nil
+
+      file = get_data_from_google_drive(credentials)
+
+      to_do.each do |type|
+        @worksheet = file.worksheets[TO_DO_TYPES.index(type)]
+        hard_send("process_#{type}")
+      end
+
+      self.data = nil if Rails.env.production?
+      Rails.cache.clear
+
+      self
+    end
+
+    protected
+
+    def process_beds
+      # Total UTI-Covid
+      create_result(1, [2, 2], [2, 3])
+      # Total UTI Não-Covid
+      create_result(2, [2, 4], [2, 5])
+      # Total Enfermaria Covid
+      create_result(3, [2, 6], [2, 7])
+      # Total Enfermaria Não-Covid
+      create_result(4, [2, 8], [2, 9])
+    end
+
+    def process_cases
+      self.cases_results = {
+        find: { city: city, reference_date: Date.today },
+        data: { total: @worksheet[2, 2], cureds: @worksheet[3, 2], deaths: @worksheet[4, 2] }
+      }
+    rescue StandardError => e
+      puts "WARNING on generate CovidCase (reference date #{Date.today}): #{e}"
+    end
+
+    def save_beds
+      hospital.beds.destroy_all
+
+      super_save!
+    end
+
+    def save_cases
+      CovidCase.find_or_initialize_by(cases_results[:find]).update(cases_results[:data])
+    end
+
+    def create_result(bed_type, total_position, busy_position)
+      total = @worksheet[*total_position]
+      busy = @worksheet[*busy_position]
+
+      (total.to_i - busy.to_i).times do |i|
+        results << create_object(bed_type, :free, i)
+      end
+
+      busy.to_i.times do |i|
+        results << create_object(bed_type, :busy, i)
+      end
+    end
+
+    def create_object(bed_type, status, iterator)
+      DataBridge::InternalObject.new(
+        hospital_slug: hospital.slug,
+        status: status,
+        bed_type: bed_type,
+        slug: "#{hospital.slug}-#{bed_type}-#{status}-#{iterator}",
+        using_ventilator: false
+      )
+    end
+
+    # Since it's a very generic class, it's very well protected to avoid unnecessary debugs
+    private
+
+    def hard_send(symbol)
+      begin
+        send_method = method(symbol)
+      rescue NameError => e
+        raise NotImplementedError, I18n.t('activerecord.passive_errors.method_not_defined', method: e.name)
+      end
+      send_method.call
+    end
+
+    def retrieve_credentials
+      credentials = Rails.application.credentials.send("#{city.slug}_spreadsheet_key")
+      return credentials if credentials
+
+      raise NotImplementedError, CREDENTIALS_NOT_FOUND_MESSAGE
+    end
+
+    def retrieve_hospital
+      return @retrieve_hospital if @retrieve_hospital
+
+      @retrieve_hospital = city.hospitals
+      hospital_countage = @retrieve_hospital.length
+
+      raise ActiveRecord::RecordNotFound, HOSPITAL_NOT_FOUND_MESSAGE if hospital_countage.zero?
+
+      puts MULTIPLE_HOSPITAL_WARNING if hospital_countage > 1
+
+      @retrieve_hospital = @retrieve_hospital.first
+      @retrieve_hospital
+    end
+  end
+end

--- a/server/config/locales/pt-BR.yml
+++ b/server/config/locales/pt-BR.yml
@@ -268,6 +268,9 @@ pt-BR:
     update: "Modificou"
     create: "Criou"
     destroy: "Deletou"
+  development_notes:
+    hospital_warning: 'CUIDADO, mais de um hospital foi encontrado, só o primeiro será usado'
+    credentials: 'Credênciais'
   activemodel:
     attributes:
       contact:
@@ -285,6 +288,11 @@ pt-BR:
             email:
               not_found: 'Não encontrado'
               already_confirmed: "Já foi confirmado"
+    passive_errors:
+      not_found:
+        one: "%{arg} não foi encontrado"
+        other: "%{arg} não foram encontrados"
+      method_not_defined: "Método '%{method}' não definido"
     models:
     attributes:
   formtastic:

--- a/server/db/migrate/20200511012836_create_cities.rb
+++ b/server/db/migrate/20200511012836_create_cities.rb
@@ -17,7 +17,7 @@ class CreateCities < ActiveRecord::Migration[6.0]
       City.create!(json_to_params(city))
     end
 
-    ['Ribeirão Preto', 'Paulínia'].each do |city_name|
+    ['Ribeirão Preto', 'Paulínia', 'Cajuru', 'Batatais'].each do |city_name|
       next if City.exists?(name: city_name)
 
       city_json = cities.find { |city_array| city_array.first == city_name }

--- a/server/db/seeds.rb
+++ b/server/db/seeds.rb
@@ -1,4 +1,6 @@
 def fake_historical hospital
+  possible_status = Bed.defined_enums['status'].keys
+
   30.times do |i|
     bed_state = BedState.create!(
       date: (30 - i).days.ago, hospital: hospital
@@ -14,6 +16,13 @@ def fake_historical hospital
           status_free: rand(1000),
           status_busy: rand(1000),
           status_unavailable: rand(1000),
+        )
+
+        Bed.create!(
+          hospital: hospital,
+          bed_type: value,
+          status: possible_status.sample,
+          using_ventilator: [true, false].sample
         )
       end
     end
@@ -157,6 +166,7 @@ if Hospital.none?
     ].each do |hospital|
       hospital = Hospital.create!(hospital)
 
+      puts "Creating data for #{hospital.name}"
       fake_historical(hospital)
     end
   end

--- a/server/db/seeds.rb
+++ b/server/db/seeds.rb
@@ -21,24 +21,21 @@ def fake_historical hospital
 end
 
 if Hospital.none?
-  rand_geocoded = -> { ([-1, 1].sample * rand(0..1.0).round(6)) }
-  cities = City.offset(rand(35)).limit(3)
+  cities = City.where(slug: %w[ribeirao-preto paulinia cajuru batatais]).map { |city| [city.slug, city] }.to_h
 
-  city = City.find_by_slug('ribeirao-preto')
-
-  unless city.nil?
+  unless cities.nil?
     [
       {
         name: 'Hospital Unimed',
         hospital_type: 2,
-        city: city,
+        city: cities['ribeirao-preto'],
         latitude: -21.225617,
         longitude: -47.816327
       },
       {
         name: 'Hospital São Lucas',
         hospital_type: 2,
-        city: city,
+        city: cities['ribeirao-preto'],
         latitude: -21.188736,
         longitude: -47.803895
       },
@@ -46,14 +43,14 @@ if Hospital.none?
         name: 'Ribeirânia (Hospital São Lucas Ribeirânia)',
         slug: 'sao-lucas-ribeirania',
         hospital_type: 2,
-        city: city,
+        city: cities['ribeirao-preto'],
         latitude: -21.200055,
         longitude: -47.787171
       },
       {
         name: 'Hospital Especializado',
         hospital_type: 2,
-        city: city,
+        city: cities['ribeirao-preto'],
         latitude: -21.207647,
         longitude: -47.823695
       },
@@ -61,28 +58,28 @@ if Hospital.none?
         name: 'Hospital Santa Casa de Misericórdia de Ribeirão Preto',
         slug: 'santa-casa-ribeirao',
         hospital_type: 1,
-        city: city,
+        city: cities['ribeirao-preto'],
         latitude: -21.167811,
         longitude: -47.805911
       },
       {
         name: 'Hospital São Paulo',
         hospital_type: 2,
-        city: city,
+        city: cities['ribeirao-preto'],
         latitude: -21.184408,
         longitude: -47.815726
       },
       {
         name: 'Beneficência Portuguesa',
         hospital_type: 1,
-        city: city,
+        city: cities['ribeirao-preto'],
         latitude: -21.180653,
         longitude: -47.813874
       },
       {
         name: 'Hospital Santa Lydia',
         hospital_type: 1,
-        city: city,
+        city: cities['ribeirao-preto'],
         latitude: -21.170,
         longitude: -47.802
       },
@@ -90,7 +87,7 @@ if Hospital.none?
         name: 'Hospital das Clínicas',
         slug: 'hc-campus-ribeirao-preto',
         hospital_type: 1,
-        city: city,
+        city: cities['ribeirao-preto'],
         latitude: -21.1624149,
         longitude: -47.8544455
       },
@@ -98,14 +95,14 @@ if Hospital.none?
         name: 'Hospital das Clínicas Unidade de Emergência',
         slug: 'hc-emergencia-ribeirao-preto',
         hospital_type: 1,
-        city: city,
+        city: cities['ribeirao-preto'],
         latitude: -21.185455,
         longitude: -47.8084284
       },
       {
         name: 'Hospital São Francisco',
         hospital_type: 1,
-        city: city,
+        city: cities['ribeirao-preto'],
         latitude: -21.1854888,
         longitude: -47.8096485
       },
@@ -113,7 +110,7 @@ if Hospital.none?
         name: 'Hospital Paulínia',
         slug: 'hospital-paulinia',
         hospital_type: 1,
-        city: City.find_by_slug('paulinia'),
+        city: cities['paulinia'],
         latitude: -22.7727157,
         longitude: -47.1591621
       },
@@ -121,7 +118,7 @@ if Hospital.none?
         name: 'Polo COVID - UPA Treze de Maio',
         slug: 'polo-covid-upa-treze-de-maio',
         hospital_type: 1,
-        city: city,
+        city: cities['ribeirao-preto'],
         latitude: -21.1761612,
         longitude: -47.7922277
       },
@@ -129,7 +126,7 @@ if Hospital.none?
         name: 'Polo COVID 2 - UPA Central',
         slug: 'polo-covid-2-upa-central',
         hospital_type: 1,
-        city: city,
+        city: cities['ribeirao-preto'],
         latitude: -21.1726925,
         longitude: -47.8143013
       },
@@ -137,9 +134,25 @@ if Hospital.none?
         name: 'Hospital Estadual de Ribeirão Preto',
         slug: 'hospital-estadual-ribeirao-preto',
         hospital_type: 1,
-        city: city,
+        city: cities['ribeirao-preto'],
         latitude: -21.2115222,
         longitude: -47.8290127
+      },
+      {
+        name: 'Hospital Batatais',
+        slug: 'hospital-batatais',
+        hospital_type: 1,
+        city: cities['batatais'],
+        latitude: -20.8947599,
+        longitude: -47.5898626
+      },
+      {
+        name: 'Hospital Cajuru',
+        slug: 'hospital-cajuru',
+        hospital_type: 1,
+        city: cities['cajuru'],
+        latitude: -21.2754479,
+        longitude: -47.3030665
       }
     ].each do |hospital|
       hospital = Hospital.create!(hospital)
@@ -158,7 +171,7 @@ if CovidCase.none?
       cureds = rand(500)
       total = cureds + deaths
 
-      covid_case = CovidCase.create!(
+      CovidCase.create!(
         city: city,
         total: rand(total..(total + 500)),
         deaths: deaths,


### PR DESCRIPTION
The current class that does the sheet threatment is 'DataBridge::Paulina', and the 'covid_case' equivalent, the new class 'DataBridge::GoogleDriveBase' aims to remove class creation and repetitive code, now, importing a city is now as simple as passing a parameter

When reviewing the pull request, keep in mind that most of the methods were extracted from 'DataBridge::Paulina', and the diffs might be hard to visualize on github as they are different files

WARNING:

- 'Batatais' and 'Cajuru' HAVEN'T BEEN ADDED YET TO CRONTAB SCHEDULE, THEIR TIME IS YET TO BE DEFINED
- Since the sheet is not retroactive, front-end might need to treat some data or define the rule on the sprint scope!
